### PR TITLE
Bump Godot version to 4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ VR modes are flat screen (with zoom) , 180°, and 360° (equirectangular or equi
 
 ## Running from source:
 
-- The project uses Godot 4.2. Make sure to get a compatble version. You can download a standalone binary on the [Godot Website](https://godotengine.org/download)
+- The project uses Godot 4.3. Make sure to get a compatble version. You can download a standalone binary on the [Godot Website](https://godotengine.org/download)
 
 - Next, get the [EIRTeam.FFmpeg](https://github.com/EIRTeam/EIRTeam.FFmpeg/releases) plugin, and unzip it into the project folder.
 


### PR DESCRIPTION
The current EIRTeam.FFmpeg version (1.1.0) requires Godot 4.3 to render properly. See: https://github.com/EIRTeam/EIRTeam.FFmpeg/issues/23#issuecomment-2175090420