### PR TITLE
Fix long paths in FileDialog options moving other elements offscreen

### DIFF
--- a/scenes/menu.gd
+++ b/scenes/menu.gd
@@ -36,6 +36,8 @@ func set_playstate(p):
 
 func _ready():
 	video_node.playback_state_changed.connect(set_playstate)
+	for btn in $FileDialog.find_children("*", "OptionButton", true, false):
+		btn.fit_to_longest_item = false
 
 func update_progress_bar(pos: float, duration: float):
 	_progress = pos


### PR DESCRIPTION
Happens easily by bookmarking long paths in Nautilus for example.
A better fix would've probably been to not subwindow the FileDialog at all so it can just use all the space it wants.